### PR TITLE
Use RUN_SECRET_DIR for AUTH_CUSTOM_CA

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -273,6 +273,7 @@ cat /etc/nginx/nginx.conf.template | sed 's/${HUB_WEBSERVER_PORT}/'"$targetWebse
 | sed 's~${CLIENT_KEY_PATH}~'"${WEBSERVER_HOME}/security/blackduck_system.key"'~g' \
 | sed 's/${NO_IPV6}/'"$ipv6Comment"'/g' \
 | sed 's/${NO_CUSTOM_CA}/'"$customCaComment"'/g' \
+| sed 's~${AUTH_CUSTOM_CA}~'"${secretsMountPath}/AUTH_CUSTOM_CA"'~g' \
 | sed 's/${NO_ALERT}/'"$alertComment"'/g' \
 | sed 's/${ALLOW_DENY_ACCESS_DIRECTIVES}/'"$allowDenyAccessDirectives"'/g' \
 | sed 's/${NO_BINARY_UPLOADS}/'"$binaryUploadComment"'/g' \

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -58,7 +58,7 @@ http {
     proxy_ssl_certificate_key       ${CLIENT_KEY_PATH};
 	
     ${NO_CUSTOM_CA} ssl_verify_client           optional_no_ca;
-    ${NO_CUSTOM_CA} ssl_client_certificate      /run/secrets/AUTH_CUSTOM_CA;
+    ${NO_CUSTOM_CA} ssl_client_certificate      ${AUTH_CUSTOM_CA};
 
     location /health-checks/liveness {
       add_header Content-Type "application/json";


### PR DESCRIPTION
We currently use RUN_SECRET_DIR  in the entrypoint to check whether AUTH_CUSTOM_CA is present. However, we also need to change the path in the nginx template.